### PR TITLE
Python 3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
   - TOXENV=django110
 
 matrix:
-  allow_failures:
-    - python: 3.5
   include:
     - python: 2.7
       env: TOXENV=quality

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test.in
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
+	cat requirements/quality-extra.in >> requirements/quality.txt
+	cat requirements/quality-extra.in >> requirements/dev.txt
+	cat requirements/dev-extra.in >> requirements/dev.txt
+	cat requirements/dev-extra.in >> requirements/travis.txt
 	# Let tox control the Django version for tests
 	sed '/Django==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt

--- a/requirements/dev-extra.in
+++ b/requirements/dev-extra.in
@@ -1,0 +1,10 @@
+# These packages are installed with `pip install pylint edx-lint`
+# To update the versions, create an empty virtualenv, run the following commands:
+# $ pip freeze > old.txt
+# $ pip install pylint edx-lint
+# $ pip freeze > new.txt
+# And replace the contents of this file with the lines in new.txt that don't exist in old.txt
+pluggy==0.4.0
+tox==2.6.0
+tox-battery==0.3
+virtualenv==15.1.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,10 +1,7 @@
 # Additional requirements for development of this application
 
 diff-cover                # Changeset diff test coverage
-edx-lint                  # For updating pylintrc
 edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management
-tox                       # virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes
 twine                     # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI

--- a/requirements/quality-extra.in
+++ b/requirements/quality-extra.in
@@ -1,0 +1,19 @@
+# These packages are installed with `pip install pylint edx-lint`
+# To update the versions, create an empty virtualenv, run the following commands:
+# $ pip freeze > old.txt
+# $ pip install pylint edx-lint
+# $ pip freeze > new.txt
+# And replace the contents of this file with the lines in new.txt that don't exist in old.txt
+astroid==1.4.9
+backports.functools-lru-cache==1.3
+configparser==3.5.0
+edx-lint==0.5.2
+isort==4.2.5
+lazy-object-proxy==1.2.2
+mccabe==0.6.1
+pylint==1.6.5
+pylint-celery==0.3
+pylint-django==0.7.2
+pylint-plugin-utils==0.2.4
+six==1.10.0
+wrapt==1.10.8

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -1,7 +1,6 @@
 # Requirements for code quality checks
 
 caniusepython3            # Additional Python 3 compatibility pylint checks
-edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,5 +1,3 @@
 # Requirements for running tests in Travis
 
 codecov                   # Code coverage reporting
-tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/web_fragments/__init__.py
+++ b/web_fragments/__init__.py
@@ -4,6 +4,6 @@ Web fragments.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'web_fragments.apps.WebFragmentsConfig'  # pylint: disable=invalid-name

--- a/web_fragments/fragment.py
+++ b/web_fragments/fragment.py
@@ -2,7 +2,10 @@
 Python representation of a web fragment.
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from collections import namedtuple
+import six
 
 FragmentResource = namedtuple("FragmentResource", "kind, data, mimetype, placement")  # pylint: disable=C0103
 
@@ -80,7 +83,7 @@ class Fragment(object):
         fragment.  It must not contain a ``<body>`` tag, or otherwise assume
         that it is the only content on the page.
         """
-        assert isinstance(content, unicode)
+        assert isinstance(content, six.text_type)
         self.content += content
 
     def _default_placement(self, mimetype):

--- a/web_fragments/tests/test_views.py
+++ b/web_fragments/tests/test_views.py
@@ -5,7 +5,7 @@
 Unit tests for web fragment views
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
 
@@ -58,7 +58,7 @@ class TestViews(TestCase):
         Test that the view returns the correct JSON when requested.
         """
         response = self.invoke_test_view(arguments=arguments, http_accept=http_accept)
-        fragment_json = json.loads(response.content)
+        fragment_json = json.loads(response.content.decode(response.charset))
         assert fragment_json['content'] == TEST_HTML
 
     @ddt.data(
@@ -71,7 +71,7 @@ class TestViews(TestCase):
         Test fragment getter when html is requested
         """
         response = self.invoke_test_view(arguments=arguments, http_accept=http_accept)
-        assert TEST_HTML in response.content
+        assert TEST_HTML in response.content.decode(response.charset)
 
     def test_render_fragment_error(self):
         """


### PR DESCRIPTION
I'm trying to get python 3 support into xblock.  The new web-fragments requirement broke that support (mostly just due to the use of the unicode keyword).  I fixed that, and a couple tests that were getting tripped up by json.loads() requiring input to be text (unicode).  

I also had to modify the requirements scripts, because pip-sync doesn't like python version specifiers.

## Reviewers:

- [x] @andy-armstrong 
- [ ] @jmbowman  (who has seen this pip-sync issue before)