### PR TITLE
Handle status codes in fragment views

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,2 @@
 # Core requirements for using this application
 
-Django                    # Web application framework
-

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -1,5 +1,7 @@
 # Requirements for documentation validation
 
+django
+
 doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
 readme_renderer           # Validates README.rst for usage on PyPI

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -1,5 +1,7 @@
 # Requirements for code quality checks
 
+django
+
 caniusepython3            # Additional Python 3 compatibility pylint checks
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,5 @@
 # Requirements for test runs.
 
-
 pytest-catchlog           # Show log output for test failures
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support

--- a/web_fragments/__init__.py
+++ b/web_fragments/__init__.py
@@ -4,6 +4,6 @@ Web fragments.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 default_app_config = 'web_fragments.apps.WebFragmentsConfig'  # pylint: disable=invalid-name

--- a/web_fragments/tests/test_views.py
+++ b/web_fragments/tests/test_views.py
@@ -24,7 +24,7 @@ from web_fragments.views import FragmentView
 @ddt.ddt
 class TestViews(TestCase):
     """
-    Unit tests for views.
+    Unit tests for web fragment views.
     """
 
     def setUp(self):
@@ -88,3 +88,11 @@ class TestViews(TestCase):
         request = self.create_mock_request()
         with pytest.raises(NotImplementedError):
             view.render_to_fragment(request)
+
+    def test_render_with_no_fragment(self):
+        """
+        Verifies that a fragment view can render with no fragment.
+        """
+        request = self.create_mock_request()
+        response = ExampleFragmentView().render_standalone_response(request, None)
+        assert response.status_code == 204

--- a/web_fragments/views.py
+++ b/web_fragments/views.py
@@ -28,8 +28,17 @@ class FragmentView(View):
         if response_format == 'json' or WEB_FRAGMENT_RESPONSE_TYPE in request.META.get('HTTP_ACCEPT', 'text/html'):
             return JsonResponse(fragment.to_dict())
         else:
-            html = self.render_to_standalone_html(request, fragment, **kwargs)
-            return HttpResponse(html)
+            return self.render_standalone_response(request, fragment, **kwargs)
+
+    def render_standalone_response(self, request, fragment, **kwargs):  # pylint: disable=unused-argument
+        """
+        Renders a standalone page as a response for the specified fragment.
+        """
+        if fragment is None:
+            return HttpResponse(status=204)
+
+        html = self.render_to_standalone_html(request, fragment, **kwargs)
+        return HttpResponse(html)
 
     def render_to_standalone_html(self, request, fragment, **kwargs):  # pylint: disable=unused-argument
         """


### PR DESCRIPTION
This change allows web fragment views to return different status codes when they render as standalone pages. In particular, if the view attempts to render ``None`` as a fragment, it can return a 204 status code.