### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ web-fragments
     :target: https://pypi.python.org/pypi/web-fragments/
     :alt: PyPI
 
-.. image:: https://travis-ci.org/edx/web-fragments.svg?branch=master
-    :target: https://travis-ci.org/edx/web-fragments
+.. image:: https://travis-ci.com/edx/web-fragments.svg?branch=master
+    :target: https://travis-ci.com/edx/web-fragments
     :alt: Travis
 
 .. image:: http://codecov.io/github/edx/web-fragments/coverage.svg?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089