### PR TITLE
Remove Django 2 tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [django22, django30, django31, django32, docs, quality]
+        toxenv: [django30, django31, django32, docs, quality]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ different ways of rendering a fragment into a page:
 
 The rationale behind this design can be found in `OEP-12`_.
 
-.. _OEP-12: http://open-edx-proposals.readthedocs.io/en/latest/oep-0012.html
+.. _OEP-12: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0012-arch-fragment-views.html
 
 The intention is that a client-side implementation will be provided in a
 subsequent version. This should provide JavaScript code to request fragements

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
@@ -60,6 +59,6 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     extras_require={
-        'Django': ['Django>=2.2,<2.3'],
+        'Django': ['Django>=3.0,<3.3'],
     }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py38-django{22,30,31,32}, docs, quality
+envlist = py38-django{30,31,32}, docs, quality
 
 [testenv]
 deps = 
-	django22: Django>=2.2,<2.3
 	django30: Django>=3.0,<3.1
 	django31: Django>=3.1,<3.2
 	django32: Django>=3.2,<3.3

--- a/web_fragments/__init__.py
+++ b/web_fragments/__init__.py
@@ -1,6 +1,6 @@
 """
 Web fragments.
 """
-__version__ = '1.1.0'
+__version__ = '2.0.0'
 
 default_app_config = 'web_fragments.apps.WebFragmentsConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Issue: [BOM-3102](https://openedx.atlassian.net/browse/BOM-3102)

With the completion of BOM-2176, Django was updated to version 3.2 in repo’s requirements. We can go ahead and now remove Django2 support from the repo